### PR TITLE
Fix up dependency references

### DIFF
--- a/src/Connect.lib.core/Connect.lib.core.csproj
+++ b/src/Connect.lib.core/Connect.lib.core.csproj
@@ -20,15 +20,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AAXClean" Version="0.4.6" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.37" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\git-clone\Mbucari\AAXClean\AAXClean.csproj" />
-    <ProjectReference Include="..\..\AaxAudioConverter\Audible.json.core\Audible.json.core.csproj" />
-    <ProjectReference Include="..\..\AaxAudioConverter\AuxLib.core\AuxLib.core.csproj" />
-    <ProjectReference Include="..\..\AaxAudioConverter\BooksDatabase.core\BooksDatabase.core.csproj" />
+    <ProjectReference Include="..\Audible.json.core\Audible.json.core.csproj" />
+    <ProjectReference Include="..\AuxLib.core\AuxLib.core.csproj" />
+    <ProjectReference Include="..\BooksDatabase.core\BooksDatabase.core.csproj" />
     <ProjectReference Include="..\CommonTypes.lib.core\CommonTypes.lib.core.csproj" />
     <ProjectReference Include="..\CommonUtil.lib.core\CommonUtil.lib.core.csproj" />
     <ProjectReference Include="..\SystemMgmt.core\SystemMgmt.core.csproj" />


### PR DESCRIPTION
Some cross-project references written on Connect.lib.core reached back outside the local repository, making it ambiguous how to compile correctly.

- Switch to using NuGet version of the third-party AAXClean library.
- Repair in-tree paths of references to projects held inside the same solution.